### PR TITLE
Feature: add support for <Route /> slots

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.4.3",
   "description": "Simple Router for Svelte 3",
   "main": "build/svero.min.js",
+  "module": "src/main.js",
   "files": [
     "build/svero.min.js",
     "README.md",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "build/svero.min.js",
   "module": "src/main.js",
   "files": [
+    "src/*.*",
     "build/svero.min.js",
     "README.md",
     "LICENSE"

--- a/src/Route.svelte
+++ b/src/Route.svelte
@@ -1,8 +1,7 @@
 <script>
   import { onMount, onDestroy, getContext } from 'svelte';
-  import ROUTER from './context';
 
-  const { assignRoute, unassignRoute, activePath } = getContext(ROUTER);
+  const { assignRoute, unassignRoute, activePath } = getContext('__svero__');
 
   export let path = '/';
   export let component = undefined;

--- a/src/Route.svelte
+++ b/src/Route.svelte
@@ -1,31 +1,23 @@
 <script>
-  import { onMount } from 'svelte';
-  
+  import { onMount, onDestroy, getContext } from 'svelte';
+  import ROUTER from './context';
+
+  const { assignRoute, unassignRoute, activePath } = getContext(ROUTER);
+
   export let path = '/';
   export let component = undefined;
   export let condition = undefined;
   export let redirect = undefined;
 
   onMount(() => {
-    assignRoute();
+    assignRoute({ path, component, condition, redirect });
   });
 
-  function assignRoute() {
-    const sveroGlobal = '__svero__';
-    
-    if (!window[sveroGlobal]) {
-      window[sveroGlobal] = {};
-    }
-
-    if (!window[sveroGlobal].paths) {
-      window[sveroGlobal].paths = [];
-    }
-
-    window[sveroGlobal].paths.push({
-      path,
-      component,
-      condition,
-      redirect
-    });
-  }
+  onDestroy(() => {
+    unassignRoute(path);
+  });
 </script>
+
+{#if $activePath === path && !component}
+  <slot />
+{/if}

--- a/src/Router.svelte
+++ b/src/Router.svelte
@@ -2,7 +2,6 @@
   import Path from 'path-parser'
   import { writable } from 'svelte/store';
   import { onMount, getContext, setContext } from 'svelte';
-  import ROUTER from './context';
 
   let t;
   let ctx;
@@ -10,12 +9,12 @@
   let currentComponent = null;
 
   const paths = [];
-  const router = getContext(ROUTER);
   const activePath = writable(null);
 
   function updateComponent(route, params = {}) {
     if (currentComponent && currentComponent.$destroy) {
       currentComponent.$destroy();
+      currentComponent = null;
     }
 
     $activePath = route.path;
@@ -167,7 +166,7 @@
     debouncedHandlePopState();
   });
 
-  setContext(ROUTER, {
+  setContext('__svero__', {
     activePath,
     paths,
     gotoRoute,

--- a/src/Router.svelte
+++ b/src/Router.svelte
@@ -41,7 +41,7 @@
 
   function handleRoute(route, result) {
     // If there is no condition, but there is a redirect, simply redirect
-    if (!route.condition && route.redirect && paths.filter(path => path.path === route.redirect).length > 0) {
+    if (!route.condition && route.redirect) {
       gotoRoute(route.redirect);
       return true;
     }

--- a/src/Router.svelte
+++ b/src/Router.svelte
@@ -73,34 +73,7 @@
       // If route matches exactly the url path, load the component
       // and stop the route checking
       if (route.path === browserPath) {
-        // If there is no condition and no component, but there is a redirect, simply redirect
-        if (!route.condition && !route.component && route.redirect) {
-          if (!paths.find(path => path.path === route.redirect)) {
-            throw Error(`svero expects <Route redirect="${route.redirect}"> to send to an existing route. ${route.redirect} does not exist.`);
-          }
-
-          gotoRoute(route.redirect);
-          return true;
-        }
-
-        // If there is condition, handle it
-        if (route.condition !== undefined && (typeof route.condition === 'boolean' || typeof route.condition === 'function')) {
-          if (typeof route.condition === 'boolean' && route.condition) {
-            updateComponent(route);
-            return true;
-          }
-
-          if (typeof route.condition === 'function' && route.condition()) {
-            updateComponent(route);
-            return true;
-          }
-
-          gotoRoute(route.redirect);
-          return true;
-        }
-
-        updateComponent(route);
-        return true;
+        return handleRoute(route);
       }
 
       // If route includes params, check if it matches with the URL

--- a/src/Router.svelte
+++ b/src/Router.svelte
@@ -39,6 +39,33 @@
     window.dispatchEvent(popEvent);
   }
 
+  function handleRoute(route, result) {
+    // If there is no condition, but there is a redirect, simply redirect
+    if (!route.condition && route.redirect && paths.filter(path => path.path === route.redirect).length > 0) {
+      gotoRoute(route.redirect);
+      return true;
+    }
+
+    // If there is condition, handle it
+    if (route.condition && (typeof route.condition === 'boolean' || typeof route.condition === 'function')) {
+      if (typeof route.condition === 'boolean' && route.condition) {
+        updateComponent(route, result);
+        return true;
+      }
+
+      if (typeof route.condition === 'function' && route.condition()) {
+        updateComponent(route, result);
+        return true;
+      }
+
+      gotoRoute(route.redirect);
+      return true;
+    }
+
+    updateComponent(route, result);
+    return true;
+  }
+
   function handlePopState() {
     paths.some((route) => {
       const browserPath = window.location.pathname;
@@ -83,60 +110,14 @@
         const result = path.test(browserPath);
 
         if (result) {
-          // If there is no condition, but there is a redirect, simply redirect
-          if (!route.condition && route.redirect && paths.filter(path => path.path === route.redirect).length > 0) {
-            gotoRoute(route.redirect);
-            return true;
-          }
-
-          // If there is condition, handle it
-          if (route.condition && (typeof route.condition === 'boolean' || typeof route.condition === 'function')) {
-            if (typeof route.condition === 'boolean' && route.condition) {
-              updateComponent(route, result);
-              return true;
-            }
-
-            if (typeof route.condition === 'function' && route.condition()) {
-              updateComponent(route, result);
-              return true;
-            }
-
-            gotoRoute(route.redirect);
-            return true;
-          }
-
-          updateComponent(route, result);
-          return true;
+          return handleRoute(route, result);
         }
       }
 
       // If route is wildcard (*), fallbacks to the component
       // and stop the route checking
       if (route.path === '*') {
-        // If there is no condition, but there is a redirect, simply redirect
-        if (!route.condition && route.redirect && paths.filter(path => path.path === route.redirect).length > 0) {
-          gotoRoute(route.redirect);
-          return true;
-        }
-
-        // If there is condition, handle it
-        if (route.condition && (typeof route.condition === 'boolean' || typeof route.condition === 'function')) {
-          if (typeof route.condition === 'boolean' && route.condition) {
-            updateComponent(route);
-            return true;
-          }
-
-          if (typeof route.condition === 'function' && route.condition()) {
-            updateComponent(route);
-            return true;
-          }
-
-          gotoRoute(route.redirect);
-          return true;
-        }
-
-        updateComponent(route);
-        return true;
+        return handleRoute(route);
       }
     });
   }

--- a/src/context.js
+++ b/src/context.js
@@ -1,0 +1,1 @@
+export default {};

--- a/src/context.js
+++ b/src/context.js
@@ -1,1 +1,0 @@
-export default {};

--- a/test/App.svelte
+++ b/test/App.svelte
@@ -15,5 +15,6 @@
     <Route path="/user/:name/:age" component={User} />
     <Route path="/admin-false" condition={false} component={User} redirect="/" />
     <Route path="/admin-true" condition={true} component={User} redirect="/" />
+    <Route path="/slot"><h3>It works!</h3></Route>
   </Router>
 </main>

--- a/test/e2e/route.js
+++ b/test/e2e/route.js
@@ -12,6 +12,13 @@ module.exports = {
       .assert.containsText('h1', 'Hello from About!')
       .end();
   },
+  '<Route> Slot rendering (/slot) Tests': (browser) => {
+    browser
+      .url('http://localhost:5001/slot')
+      .waitForElementVisible('h3')
+      .assert.containsText('h3', 'It works!')
+      .end();
+  },
   '<Route> Basic path (/{name}) Tests': (browser) => {
     browser
       .url('http://localhost:5001/about')


### PR DESCRIPTION
In order to implement `<Route>...</Route>` rendering I had to:

- Setup a shared context instead of `window[sveroGlobal]` so `assignRoute()` calls are cleaner
- Setup a reactive `$activePath` binding to enable slot-rendering on active routes only
- Instantiation of `route.component` is now optional due this ^
- Added `unassignRoute()` to remove already registered routes
- Added `debouncedHandlePopState()` to help during adding/removing routes

This would fix #17 

Also, I cleaned up a bit and removed the `paths.filter()` condition due it can lead to unexpected results, e.g.

```html
<Route path="/bar/:id" />
<Route path="/foo" redirect="/bar/123" />
```

If we check the `redirect` value against registered paths it will never be true in cases as above.