### PR TITLE
Improve Link component and fixes Route component

### DIFF
--- a/src/Link.svelte
+++ b/src/Link.svelte
@@ -2,16 +2,7 @@
   import { onMount, createEventDispatcher } from 'svelte';
   import { navigateTo } from './utils';
 
-  let cssClass = '';
-
   export let href = '/';
-  export let className = '';
-  export let title = '';
-  export { cssClass as class };
-
-  onMount(() => {
-    className = className || cssClass;
-  });
 
   const dispatch = createEventDispatcher();
 
@@ -29,4 +20,6 @@
   }
 </script>
 
-<a {href} class={className} title={title} on:click|preventDefault={onClick}><slot></slot></a>
+<a {href} {...$$props} on:click|preventDefault={onClick}>
+  <slot></slot>
+</a>

--- a/src/Route.svelte
+++ b/src/Route.svelte
@@ -20,6 +20,10 @@
   function getProps(given, required) {
     const { props, ...others } = given;
 
+    // Fix(#62):https://github.com/kazzkiq/svero/issues/62
+    // Err: required.ForEach is not a function
+    required = typeof required === 'object' ? Object.keys(required) : required;
+
     // prune all declared props from this component
     required.forEach(k => {
       delete others[k];


### PR DESCRIPTION
- Apply the use of `{...$$props}` to eliminate the need for manually passing down every prop as well as need to use a workaround for `class` on the Link component.
- Fixes the Route component as suggested by https://github.com/kazzkiq/svero/issues/62